### PR TITLE
Add response types to ticket detail

### DIFF
--- a/templates/welp_payflow/detail.html
+++ b/templates/welp_payflow/detail.html
@@ -17,15 +17,35 @@
         </div>
     </div>
 
-    <div class="ticket-detail-container">
-        {% ticket_container ticket expandido=True %}
-    </div>
-    
-    {% ticket_message_input form_action=request.get_full_path show_attachments=True cancel_url="welp_payflow:list" %}
+    {% if response_type == 'close' %}
+        <div class="ticket-detail-container">
+            {% ticket_container ticket expandido=True %}
+            <div class="bg-yellow-50 border-l-4 border-yellow-400 p-4 mb-6 rounded-r-lg">
+                {% if is_owner %}
+                    <p class="text-yellow-700">Está cerrando su propio ticket.</p>
+                {% else %}
+                    <p class="text-yellow-700">Está cerrando un ticket creado por otro usuario.</p>
+                {% endif %}
+            </div>
+        </div>
+        {% ticket_message_input form_action=process_close_url button_text="Confirmar Cierre" label_text="Comentario" placeholder="Explique el motivo del cierre" cancel_url=cancel_url required=requires_comment field_name="close_comment" %}
+    {% elif response_type == 'authorize' %}
+        <div class="ticket-detail-container">
+            {% ticket_container ticket expandido=True %}
+            <div class="bg-sky-50 border-l-4 border-sky-400 p-4 mb-6 rounded-r-lg">
+                <p class="text-sky-700">Confirme si desea autorizar este ticket.</p>
+            </div>
+        </div>
+        {% ticket_message_input form_action=authorize_url button_text="Autorizar" label_text="Comentario" placeholder="Comentario de autorización (opcional)" cancel_url=cancel_url required=False field_name="authorize_comment" %}
+    {% else %}
+        <div class="ticket-detail-container">
+            {% ticket_container ticket expandido=True %}
+        </div>
+        {% ticket_message_input form_action=request.get_full_path show_attachments=True cancel_url="welp_payflow:list" %}
+    {% endif %}
 </section>
 
 {% endblock %}
 
 {% block scripts %}
-    {% vite_asset 'frontend/js/welp_payflow/attachment_manager.js' %}
-{% endblock %} 
+    {% vite_asset 'frontend/js/welp_payflow/attachment_manager.js' %}{% endblock %} 

--- a/welp_payflow/urls.py
+++ b/welp_payflow/urls.py
@@ -1,6 +1,6 @@
 from django.urls import path
 from .views.views import home, list_tickets, ticket_detail, attachment_view, CreateTicketView, success_view, ticket_status_htmx
-from .views.others import close_ticket, process_close_ticket
+from .views.others import close_ticket, process_close_ticket, authorize_ticket
 from .views.htmx import (
     htmx_udn,
     htmx_sector,
@@ -35,5 +35,5 @@ urlpatterns += [
     path('ticket/<int:ticket_id>/confirm-close/', confirm_close_ticket_page, name='confirm-close'),
     path('htmx/ticket-status/<int:ticket_id>/', ticket_status_htmx, name='ticket_status'),
     path('tickets/<int:ticket_id>/close/', close_ticket, name='close-ticket'),
-    path('ticket/<int:ticket_id>/process-close/', process_close_ticket, name='process_close'),
-] 
+    path('ticket/<int:ticket_id>/process-close/', process_close_ticket, name='process_close'),    path('ticket/<int:ticket_id>/authorize/', authorize_ticket, name='authorize-ticket'),
+]


### PR DESCRIPTION
## Summary
- allow ticket detail page to act in multiple modes (comment, close or authorize)
- add authorize action view
- expose authorize URL

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_686ef11a29348330aea9ae6a96d091cb