### PR TITLE
Mostrar nombre en logout

### DIFF
--- a/templates/components/core/logout.html
+++ b/templates/components/core/logout.html
@@ -3,8 +3,8 @@
         <i class="text-xl sm:text-2xl md:text-xl fa fa-sign-out-alt align-middle"></i>
         <span class="ml-1.5 text-xl font-semibold align-middle tracking-wide">
             {% if user and user.first_name %}
-                {% if user.first_name|length > 10 %}
-                    {{ user.first_name|slice:":10" }}...
+                {% if user.first_name|length > 8 %}
+                    {{ user.first_name|slice:":6" }}...
                 {% else %}
                     {{ user.first_name }}
                 {% endif %}


### PR DESCRIPTION
## Summary
- truncate first name in logout link

## Testing
- `pytest -q` *(fails: KeyError: 'AWS_STORAGE_BUCKET_NAME')*

------
https://chatgpt.com/codex/tasks/task_e_686f3bab80b8833080c901786ddd3d32