### PR TITLE
Add role-based action button component

### DIFF
--- a/core/templatetags/core_tags.py
+++ b/core/templatetags/core_tags.py
@@ -191,6 +191,42 @@ def ticket_header(ticket):
 def ticket_message(message):
     return {"message": message}
 
+
+@register.inclusion_tag('components/core/ticket_action_button.html')
+def ticket_action_button(action, href='#'):
+    """Renderiza un botón de acción para tickets usando los datos de PAYFLOW_STATUSES."""
+    extra_actions = {
+        'feedback': {
+            'label': 'COMENTAR',
+            'icon': '💬',
+            'color_name': 'sky',
+        },
+        'close': {
+            'label': 'CERRAR',
+            'icon': '×',
+            'color_name': 'forest',
+        },
+    }
+
+    if action in PAYFLOW_STATUSES:
+        info = PAYFLOW_STATUSES[action]
+        label = info.get('label', action)
+        icon = info.get('icon', '')
+        color = info.get('color_name', 'forest')
+    else:
+        info = extra_actions.get(action, {})
+        label = info.get('label', action)
+        icon = info.get('icon', '')
+        color = info.get('color_name', 'forest')
+
+    return {
+        'action': action,
+        'href': href,
+        'label': label,
+        'icon': icon,
+        'color': color,
+    }
+
 @register.inclusion_tag("components/core/ticket_actions.html", takes_context=True)
 def ticket_actions(context, ticket):
     user = context['request'].user if 'request' in context else None

--- a/templates/components/core/ticket_action_button.html
+++ b/templates/components/core/ticket_action_button.html
@@ -1,0 +1,4 @@
+<a href="{{ href }}" class="ticket-action-{{ action }} bg-{{ color }}-200 border border-{{ color }}-300 text-{{ color }}-600 text-xs rounded-full py-1 px-3 inline-flex items-center font-medium hover:brightness-110 no-underline">
+    <span class="mr-1">{{ icon }}</span>
+    <span>{{ label }}</span>
+</a>

--- a/templates/components/core/ticket_actions.html
+++ b/templates/components/core/ticket_actions.html
@@ -3,21 +3,12 @@
     {% if last_message.status != 'closed' %}
         <div class="ticket-actions">
             {% if can_close_ticket %}
-            <a href="{% url 'welp_payflow:detail' ticket.id %}?close=1" class="ticket-action-close">
-                <i class="ticket-action-icon-close"></i>
-                <span>CERRAR</span>
-            </a>
+                {% ticket_action_button 'close' href=(ticket|get_absolute_url)|add:'?close=1' %}
             {% endif %}
             {% for target_status in transition_buttons %}
-                <button class="ticket-action-{{ target_status }}" style="background-color: {{ PAYFLOW_STATUSES|get_item:target_status|get_item:'color' }}; color: white;">
-                    <span>{{ PAYFLOW_STATUSES|get_item:target_status|get_item:'icon' }}</span>
-                    <span>{{ PAYFLOW_STATUSES|get_item:target_status|get_item:'label' }}</span>
-                </button>
+                {% ticket_action_button target_status href="#" %}
             {% endfor %}
-            <a href="{% url 'welp_payflow:detail' ticket.id %}" class="ticket-action-respond">
-                <i class="ticket-action-icon"></i>
-                <span>RESPONDER</span>
-            </a>
+            {% ticket_action_button 'feedback' href=(ticket|get_absolute_url) %}
         </div>
     {% else %}
         <div class="ticket-actions">

--- a/welp_payflow/constants.py
+++ b/welp_payflow/constants.py
@@ -12,6 +12,8 @@ PAYFLOW_STATUSES = {
         'is_active': os.environ.get('PAYFLOW_STATUS_OPEN_ACTIVE', 'true').lower() == 'true',
         'is_final': os.environ.get('PAYFLOW_STATUS_OPEN_FINAL', 'false').lower() == 'true',
         'transitions': os.environ.get('PAYFLOW_STATUS_OPEN_TRANSITIONS', 'authorized,closed').split(','),
+        'allowed_roles': [],  # Estado inicial, no accesible directamente
+        'color_name': 'red',
     },
     'authorized': {
         'label': os.environ.get('PAYFLOW_STATUS_AUTHORIZED_LABEL', 'Autorizado'),
@@ -21,6 +23,8 @@ PAYFLOW_STATUSES = {
         'is_active': os.environ.get('PAYFLOW_STATUS_AUTHORIZED_ACTIVE', 'true').lower() == 'true',
         'is_final': os.environ.get('PAYFLOW_STATUS_AUTHORIZED_FINAL', 'false').lower() == 'true',
         'transitions': os.environ.get('PAYFLOW_STATUS_AUTHORIZED_TRANSITIONS', 'budgeted,closed').split(','),
+        'allowed_roles': ['supervisor', 'manager'],
+        'color_name': 'purple',
     },
     'budgeted': {
         'label': os.environ.get('PAYFLOW_STATUS_BUDGETED_LABEL', 'Presupuestado'),
@@ -30,6 +34,8 @@ PAYFLOW_STATUSES = {
         'is_active': os.environ.get('PAYFLOW_STATUS_BUDGETED_ACTIVE', 'true').lower() == 'true',
         'is_final': os.environ.get('PAYFLOW_STATUS_BUDGETED_FINAL', 'false').lower() == 'true',
         'transitions': os.environ.get('PAYFLOW_STATUS_BUDGETED_TRANSITIONS', 'payment_authorized,rejected,closed').split(','),
+        'allowed_roles': ['purchase_manager', 'technician'],
+        'color_name': 'green',
     },
     'rejected': {
         'label': os.environ.get('PAYFLOW_STATUS_REJECTED_LABEL', 'Rechazado'),
@@ -39,6 +45,8 @@ PAYFLOW_STATUSES = {
         'is_active': os.environ.get('PAYFLOW_STATUS_REJECTED_ACTIVE', 'true').lower() == 'true',
         'is_final': os.environ.get('PAYFLOW_STATUS_REJECTED_FINAL', 'false').lower() == 'true',
         'transitions': os.environ.get('PAYFLOW_STATUS_REJECTED_TRANSITIONS', 'budgeted,closed').split(','),
+        'allowed_roles': ['supervisor', 'manager'],
+        'color_name': 'yellow',
     },
     'payment_authorized': {
         'label': os.environ.get('PAYFLOW_STATUS_PAYMENT_AUTH_LABEL', 'Pago Autorizado'),
@@ -48,6 +56,8 @@ PAYFLOW_STATUSES = {
         'is_active': os.environ.get('PAYFLOW_STATUS_PAYMENT_AUTH_ACTIVE', 'true').lower() == 'true',
         'is_final': os.environ.get('PAYFLOW_STATUS_PAYMENT_AUTH_FINAL', 'false').lower() == 'true',
         'transitions': os.environ.get('PAYFLOW_STATUS_PAYMENT_AUTH_TRANSITIONS', 'processing_payment,closed').split(','),
+        'allowed_roles': ['manager'],
+        'color_name': 'orange',
     },
     'processing_payment': {
         'label': os.environ.get('PAYFLOW_STATUS_PROCESSING_LABEL', 'Procesando Pago'),
@@ -57,6 +67,8 @@ PAYFLOW_STATUSES = {
         'is_active': os.environ.get('PAYFLOW_STATUS_PROCESSING_ACTIVE', 'true').lower() == 'true',
         'is_final': os.environ.get('PAYFLOW_STATUS_PROCESSING_FINAL', 'false').lower() == 'true',
         'transitions': os.environ.get('PAYFLOW_STATUS_PROCESSING_TRANSITIONS', 'shipping,closed').split(','),
+        'allowed_roles': ['purchase_manager'],
+        'color_name': 'cyan',
     },
     'shipping': {
         'label': os.environ.get('PAYFLOW_STATUS_SHIPPING_LABEL', 'En Envío'),
@@ -66,6 +78,8 @@ PAYFLOW_STATUSES = {
         'is_active': os.environ.get('PAYFLOW_STATUS_SHIPPING_ACTIVE', 'true').lower() == 'true',
         'is_final': os.environ.get('PAYFLOW_STATUS_SHIPPING_FINAL', 'false').lower() == 'true',
         'transitions': os.environ.get('PAYFLOW_STATUS_SHIPPING_TRANSITIONS', 'closed').split(','),
+        'allowed_roles': ['purchase_manager', 'technician'],
+        'color_name': 'violet',
     },
     'closed': {
         'label': os.environ.get('PAYFLOW_STATUS_CLOSED_LABEL', 'Cerrado'),
@@ -75,6 +89,8 @@ PAYFLOW_STATUSES = {
         'is_active': os.environ.get('PAYFLOW_STATUS_CLOSED_ACTIVE', 'false').lower() == 'true',
         'is_final': os.environ.get('PAYFLOW_STATUS_CLOSED_FINAL', 'true').lower() == 'true',
         'transitions': os.environ.get('PAYFLOW_STATUS_CLOSED_TRANSITIONS', '').split(',') if os.environ.get('PAYFLOW_STATUS_CLOSED_TRANSITIONS') else [],
+        'allowed_roles': [],  # No hay transiciones desde cerrado
+        'color_name': 'forest',
     },
     'unknown': {
         'label': 'Desconocido',
@@ -84,6 +100,8 @@ PAYFLOW_STATUSES = {
         'is_active': False,
         'is_final': False,
         'transitions': [],
+        'allowed_roles': [],
+        'color_name': 'gray',
     },
 }
 

--- a/welp_payflow/utils.py
+++ b/welp_payflow/utils.py
@@ -119,14 +119,16 @@ def can_user_transition_ticket(user, ticket, target_status):
     possible_transitions = PAYFLOW_STATUSES.get(current_status, {}).get('transitions', [])
     if target_status not in possible_transitions:
         return False
-    responsible_roles = PAYFLOW_STATUS_FLOW.get(target_status, {}).get('responsible_roles', [])
-    if not responsible_roles:
-        return user.is_superuser
+    allowed_roles = PAYFLOW_STATUSES.get(target_status, {}).get('allowed_roles', [])
+    if user.is_superuser:
+        return True
+    if not allowed_roles:
+        return False
     user_roles = getattr(user, 'payflow_roles', None)
     if user_roles is None:
         return False
     for role in user.payflow_roles.all():
-        if role.get_role_type() in responsible_roles:
+        if role.get_role_type() in allowed_roles:
             return True
     return False
 


### PR DESCRIPTION
## Summary
- configure tailwind color names for Payflow statuses
- add `ticket_action_button` template tag and component
- render action buttons via new component

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(fails: KeyError: 'AWS_STORAGE_BUCKET_NAME')*

------
https://chatgpt.com/codex/tasks/task_e_686fb2f459648330a4fa725446230afc