### PR TITLE
Fix payflow attachment preview

### DIFF
--- a/templates/welp_payflow/attachment.html
+++ b/templates/welp_payflow/attachment.html
@@ -26,17 +26,94 @@
     <div class="attachment-content z-0">
         {% if file_type == 'image' %}
             <div class="attachment-image-container flex justify-center items-center">
-                <img src="{{ attachment.file.url }}" 
-                     alt="{{ attachment.file.name|basename }}" 
-                     class="attachment-image max-h-[70vh] rounded shadow border mx-auto">
+                <img src="{{ attachment.file.url }}"
+                     alt="{{ attachment.file.name|basename }}"
+                     class="attachment-image max-w-full max-h-[70vh] rounded shadow border mx-auto">
             </div>
         {% elif file_type == 'pdf' %}
-            <div id="pdf-container" class="h-[80vh] w-full"></div>
-            <script src="https://cdnjs.cloudflare.com/ajax/libs/pdfobject/2.2.14/pdfobject.min.js"></script>
+            <div id="pdf-container" class="attachment-pdf-container flex flex-col items-center"></div>
+            <div id="pdf-controls" class="mt-2 flex justify-center gap-4"></div>
+            <script src="https://cdnjs.cloudflare.com/ajax/libs/pdf.js/3.4.120/pdf.min.js"></script>
             <script>
-                PDFObject.embed("{{ attachment.file.url }}#view=FitH", "#pdf-container", {
-                    fallbackLink: "<p class='text-center mt-4'>Tu navegador no soporta PDFs. <a href='{{ attachment.file.url }}' target='_blank'>Descargar</a></p>"
+                const url = "{{ attachment.file.url }}";
+                const container = document.getElementById('pdf-container');
+                const controls = document.getElementById('pdf-controls');
+                const canvas = document.createElement('canvas');
+                canvas.className = 'w-full border rounded';
+                container.appendChild(canvas);
+                const ctx = canvas.getContext('2d');
+
+                const pdfjsLib = window['pdfjs-dist/build/pdf'];
+                pdfjsLib.GlobalWorkerOptions.workerSrc = 'https://cdnjs.cloudflare.com/ajax/libs/pdf.js/3.4.120/pdf.worker.min.js';
+
+                let pdfDoc = null,
+                    pageNum = 1,
+                    pageRendering = false;
+
+                function renderPage(num) {
+                    pageRendering = true;
+                    pdfDoc.getPage(num).then(page => {
+                        const viewport = page.getViewport({ scale: 1 });
+                        const width = container.clientWidth;
+                        const scale = width / viewport.width;
+                        const scaledViewport = page.getViewport({ scale });
+                        canvas.height = scaledViewport.height;
+                        canvas.width = scaledViewport.width;
+                        const renderCtx = { canvasContext: ctx, viewport: scaledViewport };
+                        page.render(renderCtx).promise.then(() => {
+                            pageRendering = false;
+                            pageInfo.textContent = `${num} / ${pdfDoc.numPages}`;
+                        });
+                    });
+                }
+
+                function queueRenderPage(num) {
+                    if (pageRendering) {
+                        setTimeout(() => queueRenderPage(num), 100);
+                    } else {
+                        renderPage(num);
+                    }
+                }
+
+                function onPrevPage() {
+                    if (pageNum <= 1) return;
+                    pageNum--;
+                    queueRenderPage(pageNum);
+                }
+
+                function onNextPage() {
+                    if (pageNum >= pdfDoc.numPages) return;
+                    pageNum++;
+                    queueRenderPage(pageNum);
+                }
+
+                const prevBtn = document.createElement('button');
+                prevBtn.type = 'button';
+                prevBtn.className = 'button-minimal';
+                prevBtn.textContent = '« Página anterior';
+                prevBtn.addEventListener('click', onPrevPage);
+
+                const nextBtn = document.createElement('button');
+                nextBtn.type = 'button';
+                nextBtn.className = 'button-minimal';
+                nextBtn.textContent = 'Página siguiente »';
+                nextBtn.addEventListener('click', onNextPage);
+
+                const pageInfo = document.createElement('span');
+                pageInfo.className = 'text-sm self-center';
+
+                controls.appendChild(prevBtn);
+                controls.appendChild(pageInfo);
+                controls.appendChild(nextBtn);
+
+                pdfjsLib.getDocument(url).promise.then(pdf => {
+                    pdfDoc = pdf;
+                    renderPage(pageNum);
+                }).catch(() => {
+                    container.innerHTML = `<p class='text-center mt-4'>No se pudo cargar el PDF. <a href='${url}' target='_blank'>Descargar</a></p>`;
+                    controls.remove();
                 });
+                window.addEventListener('resize', () => renderPage(pageNum));
             </script>
         {% else %}
             <div class="attachment-file-preview">


### PR DESCRIPTION
## Summary
- tweak attachment view to show image thumbnails correctly
- use PDF.js for embedded previews with pagination

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'rest_framework')*

------
https://chatgpt.com/codex/tasks/task_e_68731cdb843c83308957a526cdcfb8c4